### PR TITLE
Custom timeout added

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,8 @@ use Mix.Config
 config :cloudinary_uploader,
   api_key: "lol",
   api_secret: "lol",
-  cloud_name: "lol"
+  cloud_name: "lol",
+  timeout: 500
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/lib/cloudinary_uploader/uploader.ex
+++ b/lib/cloudinary_uploader/uploader.ex
@@ -40,7 +40,12 @@ defmodule CloudinaryUploader.Uploader do
   defp call(opts) do
     if(is_nil(Application.get_env(:cloudinary_uploader, :cloud_name)), do: raise(ParseError, message: "cloudinary cloud_name is not set in application variables"))
     url = "#{@base_url}#{Application.get_env(:cloudinary_uploader, :cloud_name)}/#{Map.get(opts, :resource_type)}/upload"
-    HTTPoison.request!(:post, url, Poison.encode!(opts), @cloudinary_headers)
+    options = if is_nil(Application.get_env(:cloudinary_uploader, :timeout)) do
+        []
+      else
+        [timeout: Application.get_env(:cloudinary_uploader, :timeout)]
+      end
+    HTTPoison.request!(:post, url, Poison.encode!(opts), @cloudinary_headers, options)
   end
 
   defp parse_response(response) do


### PR DESCRIPTION
If the audio and video file size is larger, the upload request to HTTPoison is failing due to timeout. 
This gives a option to add custom timeout for uploading files.