### PR TITLE
Custom timeout changed to run test cases

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,7 @@ config :cloudinary_uploader,
   api_key: System.get_env("API_KEY"),
   api_secret: System.get_env("API_SECRET"),
   cloud_name: System.get_env("CLOUD_NAME"),
-  timeout: 500
+  timeout: 1000
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,7 @@ config :cloudinary_uploader,
   api_key: System.get_env("API_KEY"),
   api_secret: System.get_env("API_SECRET"),
   cloud_name: System.get_env("CLOUD_NAME"),
-  timeout: 1500
+  timeout: 2000
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,7 @@ config :cloudinary_uploader,
   api_key: System.get_env("API_KEY"),
   api_secret: System.get_env("API_SECRET"),
   cloud_name: System.get_env("CLOUD_NAME"),
-  timeout: 1000
+  timeout: 1500
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment


### PR DESCRIPTION
Video upload in test cases is sometimes taking more than 500ms, which is making the Travis build fail. Hence increased the custom timeout to 1500ms